### PR TITLE
Preview of site with lightning clients listing and donation button (#15)

### DIFF
--- a/.github/workflows/build-lncm-site-current-branch-to-tor.yml
+++ b/.github/workflows/build-lncm-site-current-branch-to-tor.yml
@@ -23,6 +23,8 @@ jobs:
         run: rm -fr node_modules        
       - name: Change Directory to PUBLIC
         run: cd public/
+      - name: Do a LS
+        run: ls
       - name: Push contents of whats in PUBLIC dir to nolim1t TOR site
         uses: nolim1t/actions/torscp@0.2.0
         env:

--- a/.github/workflows/build-lncm-site-current-branch-to-tor.yml
+++ b/.github/workflows/build-lncm-site-current-branch-to-tor.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Remove node_modules
         run: rm -fr node_modules        
       - name: Change Directory to PUBLIC
-        run: cd public/ && ls
-      - name: Push contents of MASTER to nolim1t TOR site
+        run: cd public/
+      - name: Push contents of whats in PUBLIC dir to nolim1t TOR site
         uses: nolim1t/actions/torscp@0.2.0
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -48,7 +48,7 @@ Wallets where you don't have full control of your funds (works like a bank, but 
 
 Once you have one of these wallets installed, you may add some funds similar to how you would fund a normal wallet and try the donate button (no need to send a lot, lightning works with a fraction of a cent!). 
 
-We also have a [proof of concept merchant in Chiang Mai](https://goo.gl/maps/R33gihUTVwtsrgJJ9) where you can spend real money with a discount.
+We also have a [proof of concept merchant in Chiang Mai](https://goo.gl/maps/R33gihUTVwtsrgJJ9) where you can spend real money with 10% discount. If you have any other merchant suggestions (ideally they need to want to keep the bitcoins), please [suggest them to us](https://github.com/lncm/ideas/issues)
 
 <div id="bottle-payment-button" data-corner="25px" data-fill="filled" data-size="small" data-color="#000000" data-textColor="#FFD54F" data-service="bottle" data-name="Send%20some%20spare%20sats%20to%20LNCM" data-avatar="https://cdn.bottle.li/userimg/a6a7a37fb60c1d66cee5c8f2fbe8151f4e4541bc660f6e72fcef13bbf24f84f6.jpg" data-username="mZc5hVov9V5vhPNAjPnM3W26W4rwgKDq3wGb8W87hLwX" data-text="donate" data-url="https://pay.bottle.li/send/social/" ></div>
 <script src="https://cdn.bottle.li/button/bb.min.js"></script>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -48,7 +48,7 @@ Wallets where you don't have full control of your funds (works like a bank, but 
 
 Once you have one of these wallets installed, you may add some funds similar to how you would fund a normal wallet and try the donate button (no need to send a lot, lightning works with a fraction of a cent!). 
 
-We also have a [proof of concept merchant in Chiang Mai](https://goo.gl/maps/R33gihUTVwtsrgJJ9) where you can spend real money with 10% discount. If you have any other merchant suggestions (ideally they need to want to keep the bitcoins), please [suggest them to us](https://github.com/lncm/ideas/issues)
+We also have a [proof of concept merchant in Chiang Mai](https://goo.gl/maps/R33gihUTVwtsrgJJ9) where you can spend real money with 10% discount. 
 
 <div id="bottle-payment-button" data-corner="25px" data-fill="filled" data-size="small" data-color="#000000" data-textColor="#FFD54F" data-service="bottle" data-name="Send%20some%20spare%20sats%20to%20LNCM" data-avatar="https://cdn.bottle.li/userimg/a6a7a37fb60c1d66cee5c8f2fbe8151f4e4541bc660f6e72fcef13bbf24f84f6.jpg" data-username="mZc5hVov9V5vhPNAjPnM3W26W4rwgKDq3wGb8W87hLwX" data-text="donate" data-url="https://pay.bottle.li/send/social/" ></div>
 <script src="https://cdn.bottle.li/button/bb.min.js"></script>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -46,7 +46,9 @@ Wallets where you don't have full control of your funds (works like a bank, but 
 
 ### Ready to try?
 
-Once you have one of these wallets installed, you may add some funds similar to how you would fund a normal wallet and try the donate button (no need to send a lot, lightning works with a fraction of a cent!).
+Once you have one of these wallets installed, you may add some funds similar to how you would fund a normal wallet and try the donate button (no need to send a lot, lightning works with a fraction of a cent!). 
 
-<div id="bottle-payment-button" data-corner="25px" data-fill="filled" data-size="small" data-color="#000000" data-textColor="#FFD54F" data-service="bottle" data-name="Donate%20to%20LNCM" data-avatar="https://cdn.bottle.li/userimg/a6a7a37fb60c1d66cee5c8f2fbe8151f4e4541bc660f6e72fcef13bbf24f84f6.jpg" data-username="mZc5hVov9V5vhPNAjPnM3W26W4rwgKDq3wGb8W87hLwX" data-text="donate" data-url="https://pay.bottle.li/send/social/" ></div>
+We also have a [proof of concept merchant in Chiang Mai](https://goo.gl/maps/R33gihUTVwtsrgJJ9) where you can spend real money with a discount.
+
+<div id="bottle-payment-button" data-corner="25px" data-fill="filled" data-size="small" data-color="#000000" data-textColor="#FFD54F" data-service="bottle" data-name="Send%20some%20spare%20sats%20to%20LNCM" data-avatar="https://cdn.bottle.li/userimg/a6a7a37fb60c1d66cee5c8f2fbe8151f4e4541bc660f6e72fcef13bbf24f84f6.jpg" data-username="mZc5hVov9V5vhPNAjPnM3W26W4rwgKDq3wGb8W87hLwX" data-text="donate" data-url="https://pay.bottle.li/send/social/" ></div>
 <script src="https://cdn.bottle.li/button/bb.min.js"></script>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -8,7 +8,7 @@ Our aim is to bring about real-world use of lightning by making it *easier* and 
 
 We dream of a world where anyone can transact freely, without excessive fees, censorship, fear of confiscation or loss of privacy.
 
-### Join us
+## Join us
 
 We hold regular [meetings](https://github.com/lncm/ideas) around Chiang Mai to present and discuss our current projects.
 
@@ -16,7 +16,8 @@ All contributors are welcome to join and all forms of contribution are highly va
 
 Feel free to get in touch via Twitter [direct message](https://twitter.com/messages/compose?recipient_id=1030362335485906944), or otherwise.
 
-### Why Lightning?
+
+## Why Lightning?
 
 The [Lightning Network](https://en.bitcoin.it/wiki/Lightning_Network) allows payments to be made across the Internet within the blink of an eye.
 
@@ -24,11 +25,11 @@ Payments can be smaller than fractions of a cent thus allowing for fairer billin
 
 Onion-style routing significantly increases financial privacy of transacting parties and since channel peers pay each other directly using Bitcoin transactions, no third party must be trusted.
 
-### Try out lightning!
+## Try out lightning!
 
 For a proof of concept demo, we recommend the following lightning clients:
 
-#### Non-Custodial Wallets
+### Non-Custodial Wallets
 
 Wallets where you have full control over your funds
 
@@ -36,12 +37,14 @@ Wallets where you have full control over your funds
 - Linux/Windows/Mac/Mobile: [Lightning labs desktop](https://github.com/lightninglabs/lightning-app)  [Android/iOS version](https://github.com/lightninglabs/lightning-app/tree/master/mobile)
 - Android only: [Eclair Wallet](https://github.com/ACINQ/eclair-mobile)
 
-#### Custodial Wallets
+### Custodial Wallets
 
 Wallets where you don't have full control of your funds (works like a bank, but not regulated)
 
 - iOS and Android: [Wallet of Satoshi](https://www.walletofsatoshi.com/)
 - iOS and Android: [BlueWallet](https://bluewallet.io/) (Note that [by default it is custodial](https://lndhub.io/about) but [you can set up your own version](https://github.com/BlueWallet/LndHub). )
+
+### Ready to try?
 
 Once you have one of these wallets installed, you may add some funds similar to how you would fund a normal wallet and try the donate button (no need to send a lot, lightning works with a fraction of a cent!).
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -24,6 +24,26 @@ Payments can be smaller than fractions of a cent thus allowing for fairer billin
 
 Onion-style routing significantly increases financial privacy of transacting parties and since channel peers pay each other directly using Bitcoin transactions, no third party must be trusted.
 
+### Try out lightning!
+
+For a proof of concept demo, we recommend the following lightning clients:
+
+#### Non-Custodial Wallets
+
+Wallets where you have full control over your funds
+
+- iOS and Android: [Breez Wallet](https://breez.technology/)
+- Linux/Windows/Mac/Mobile: [Lightning labs desktop](https://github.com/lightninglabs/lightning-app)  [Android/iOS version](https://github.com/lightninglabs/lightning-app/tree/master/mobile)
+- Android only: [Eclair Wallet](https://github.com/ACINQ/eclair-mobile)
+
+#### Custodial Wallets
+
+Wallets where you don't have full control of your funds (works like a bank, but not regulated)
+
+- iOS and Android: [Wallet of Satoshi](https://www.walletofsatoshi.com/)
+- iOS and Android: [BlueWallet](https://bluewallet.io/) (Note that [by default it is custodial](https://lndhub.io/about) but [you can set up your own version](https://github.com/BlueWallet/LndHub). )
+
+Once you have one of these wallets installed, you may add some funds similar to how you would fund a normal wallet and try the donate button (no need to send a lot, lightning works with a fraction of a cent!).
 
 <div id="bottle-payment-button" data-corner="25px" data-fill="filled" data-size="small" data-color="#000000" data-textColor="#FFD54F" data-service="bottle" data-name="Donate%20to%20LNCM" data-avatar="https://cdn.bottle.li/userimg/a6a7a37fb60c1d66cee5c8f2fbe8151f4e4541bc660f6e72fcef13bbf24f84f6.jpg" data-username="mZc5hVov9V5vhPNAjPnM3W26W4rwgKDq3wGb8W87hLwX" data-text="donate" data-url="https://pay.bottle.li/send/social/" ></div>
 <script src="https://cdn.bottle.li/button/bb.min.js"></script>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -23,3 +23,7 @@ The [Lightning Network](https://en.bitcoin.it/wiki/Lightning_Network) allows pay
 Payments can be smaller than fractions of a cent thus allowing for fairer billing methods, based on actual usage.
 
 Onion-style routing significantly increases financial privacy of transacting parties and since channel peers pay each other directly using Bitcoin transactions, no third party must be trusted.
+
+
+<div id="bottle-payment-button" data-corner="25px" data-fill="filled" data-size="small" data-color="#000000" data-textColor="#FFD54F" data-service="bottle" data-name="Donate%20to%20LNCM" data-avatar="https://cdn.bottle.li/userimg/a6a7a37fb60c1d66cee5c8f2fbe8151f4e4541bc660f6e72fcef13bbf24f84f6.jpg" data-username="mZc5hVov9V5vhPNAjPnM3W26W4rwgKDq3wGb8W87hLwX" data-text="donate" data-url="https://pay.bottle.li/send/social/" ></div>
+<script src="https://cdn.bottle.li/button/bb.min.js"></script>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -50,7 +50,7 @@ Once you have one of these wallets installed, you may add some funds similar to 
 
 Once the lightning wallets are funded, and there are funds available, you may try paying.
 
-If you're in Chiang Mai - we have a [merchant in Chiang Mai](https://goo.gl/maps/R33gihUTVwtsrgJJ9) where you can spend real money with 10% discount. The food and drink is quite high quality.
+If you're in Chiang Mai - we have a [merchant in Chiang Mai](https://goo.gl/maps/R33gihUTVwtsrgJJ9) where you can spend real money with 10% discount. The menu is quite varied, and the food and drink is quite high quality with a nice selection of local beers and craft beers too.
 
 Otherwise feel free to try the donation button, to experience microtipping (you can send fractions of a cent!)
 

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -48,7 +48,7 @@ Wallets where you don't have full control of your funds (works like a bank, but 
 
 Once you have one of these wallets installed, you may add some funds similar to how you would fund a normal wallet and try the donate button (no need to send a lot, lightning works with a fraction of a cent!). 
 
-We also have a [proof of concept merchant in Chiang Mai](https://goo.gl/maps/R33gihUTVwtsrgJJ9) where you can spend real money with 10% discount. 
+We also have a [proof of concept merchant in Chiang Mai](https://goo.gl/maps/R33gihUTVwtsrgJJ9) where you can spend real money with 10% discount.
 
 <div id="bottle-payment-button" data-corner="25px" data-fill="filled" data-size="small" data-color="#000000" data-textColor="#FFD54F" data-service="bottle" data-name="Send%20some%20spare%20sats%20to%20LNCM" data-avatar="https://cdn.bottle.li/userimg/a6a7a37fb60c1d66cee5c8f2fbe8151f4e4541bc660f6e72fcef13bbf24f84f6.jpg" data-username="mZc5hVov9V5vhPNAjPnM3W26W4rwgKDq3wGb8W87hLwX" data-text="donate" data-url="https://pay.bottle.li/send/social/" ></div>
 <script src="https://cdn.bottle.li/button/bb.min.js"></script>

--- a/src/pages/index.md
+++ b/src/pages/index.md
@@ -46,9 +46,13 @@ Wallets where you don't have full control of your funds (works like a bank, but 
 
 ### Ready to try?
 
-Once you have one of these wallets installed, you may add some funds similar to how you would fund a normal wallet and try the donate button (no need to send a lot, lightning works with a fraction of a cent!). 
+Once you have one of these wallets installed, you may add some funds similar to how you would fund a normal wallet. 
 
-We also have a [proof of concept merchant in Chiang Mai](https://goo.gl/maps/R33gihUTVwtsrgJJ9) where you can spend real money with 10% discount.
+Once the lightning wallets are funded, and there are funds available, you may try paying.
 
-<div id="bottle-payment-button" data-corner="25px" data-fill="filled" data-size="small" data-color="#000000" data-textColor="#FFD54F" data-service="bottle" data-name="Send%20some%20spare%20sats%20to%20LNCM" data-avatar="https://cdn.bottle.li/userimg/a6a7a37fb60c1d66cee5c8f2fbe8151f4e4541bc660f6e72fcef13bbf24f84f6.jpg" data-username="mZc5hVov9V5vhPNAjPnM3W26W4rwgKDq3wGb8W87hLwX" data-text="donate" data-url="https://pay.bottle.li/send/social/" ></div>
+If you're in Chiang Mai - we have a [merchant in Chiang Mai](https://goo.gl/maps/R33gihUTVwtsrgJJ9) where you can spend real money with 10% discount. The food and drink is quite high quality.
+
+Otherwise feel free to try the donation button, to experience microtipping (you can send fractions of a cent!)
+
+<div id="bottle-payment-button" data-corner="25px" data-fill="filled" data-size="small" data-color="#000000" data-textColor="#FFD54F" data-service="bottle" data-name="Donate%20to%20LNCM" data-avatar="https://cdn.bottle.li/userimg/a6a7a37fb60c1d66cee5c8f2fbe8151f4e4541bc660f6e72fcef13bbf24f84f6.jpg" data-username="mZc5hVov9V5vhPNAjPnM3W26W4rwgKDq3wGb8W87hLwX" data-text="donate" data-url="https://pay.bottle.li/send/social/" ></div>
 <script src="https://cdn.bottle.li/button/bb.min.js"></script>


### PR DESCRIPTION
Donation button (will close #15)  proof of concept. This should also close #10 and close #1  too.

## Staging site

Previewable at: [lncm onion](http://lncm5rjtcacoc6yf.onion)

You need to turn on all the javascript and stuff for it to be usable. Perhaps pointing a normal browser with TOR socks should work.

## Tasks

- [x] First iteration
- [x] Test out staging script (deploy to tor site as a "staging site" on PR)
- [x] Test out donation button
- [x] Discuss
- [ ] Merge

## Donation button

Will use bottle.li for lightning tips. Amounts shouldn't be a lot of money and access is only to those who have access to the social media account. Risk is low for now.

When theres a sizeable amount in there should move it to the multi-sig.